### PR TITLE
don't call start/stop actions so often

### DIFF
--- a/lib/cloud/cycler/schedule.rb
+++ b/lib/cloud/cycler/schedule.rb
@@ -69,8 +69,8 @@ class Cloud::Cycler::Schedule
     sprintf("#{sched} %02d%02d-%02d%02d", @start_hr, @start_min, @stop_hr, @stop_min)
   end
 
-  # Returns true if the current time is within the hours defined by the schedule
-  def active?
+  # Returns the start and stop times for *today's* operational window
+  def window
     now = Time.now
     today = now.to_date
 
@@ -85,6 +85,21 @@ class Cloud::Cycler::Schedule
       stop += 86400
     end
 
+    [ start, now, stop ]
+  end
+
+  # Returns true if the current time is within the hours defined by the schedule
+  def active?
+    start, now, stop = window
+
     now.between?(start, stop)
+  end
+
+  # Returns true if the current time is within an hour of the start or stop
+  # time in the schedule
+  def interesting?
+    start, now, stop = window
+
+    now.between?(start,start+3600) || now.between?(stop,stop+3600)
   end
 end

--- a/lib/cloud/cycler/task.rb
+++ b/lib/cloud/cycler/task.rb
@@ -99,7 +99,12 @@ class Cloud::Cycler::Task
   # Process each of the included resources. Looks for settings in dynamodb
   # which overwrite the task settings.
   def run
-    info { "Starting task: #{@name}" }
+    if @schedule.interesting?
+      info { "Starting task: #{@name}" }
+    else
+      info { "Skipping task: #{@name}" }
+      return
+    end
     @includes.each do |type, ids|
       klass = TYPES[type]
       raise Cloud::Cycler::TaskFailure.new("Unknown type #{type}") if klass.nil?

--- a/lib/cloud/cycler/version.rb
+++ b/lib/cloud/cycler/version.rb
@@ -2,5 +2,5 @@ require 'cloud/cycler/namespace'
 
 # Just contains the version for gemspec, etc to pull in
 class Cloud::Cycler
-  VERSION = '2.1.17'
+  VERSION = '2.1.18'
 end


### PR DESCRIPTION
Old behaviour: start/stop actions are invoked every time cloudcycler is invoked,
regardless of whether it is likely anything needs to be done

New behaviour: only run the start/stop actions in two time windows:
1. for an hour after the beginning of the scheduled active time
2. for an hour after the end of the scheduled active time
